### PR TITLE
Add environment-based logging checks

### DIFF
--- a/backend/src/guards/auth.guard.ts
+++ b/backend/src/guards/auth.guard.ts
@@ -1,6 +1,8 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { UserRole, Permission, hasPermission, JWTPayload } from '../types/auth';
 
+const shouldLog = process.env.NODE_ENV !== 'production';
+
 // Override @fastify/jwt module to use our JWTPayload type
 declare module '@fastify/jwt' {
   interface FastifyJWT {
@@ -25,9 +27,13 @@ export const requireAuth = async (request: FastifyRequest, reply: FastifyReply) 
       });
     }
     
-    console.log(`Auth: User ${request.user.email} (${request.user.role}) authenticated`);
+    if (shouldLog) {
+      console.log(`Auth: User ${request.user.email} (${request.user.role}) authenticated`);
+    }
   } catch (err: any) {
-    console.error('Authentication failed:', err.message);
+    if (shouldLog) {
+      console.error('Authentication failed:', err.message);
+    }
     return reply.code(401).send({
       error: 'Authentication required',
       message: 'Invalid or missing token',
@@ -49,7 +55,9 @@ export const requireRole = (requiredRole: UserRole) => {
     const user = request.user!;
     
     if (user.role !== requiredRole) {
-      console.log(`Auth: User ${user.email} role ${user.role} insufficient, required: ${requiredRole}`);
+      if (shouldLog) {
+        console.log(`Auth: User ${user.email} role ${user.role} insufficient, required: ${requiredRole}`);
+      }
       return reply.code(403).send({
         error: 'Insufficient privileges',
         message: `Role ${requiredRole} required`,
@@ -59,7 +67,9 @@ export const requireRole = (requiredRole: UserRole) => {
       });
     }
     
-    console.log(`Auth: User ${user.email} has required role: ${requiredRole}`);
+    if (shouldLog) {
+      console.log(`Auth: User ${user.email} has required role: ${requiredRole}`);
+    }
   };
 };
 
@@ -76,7 +86,9 @@ export const requireAnyRole = (allowedRoles: UserRole[]) => {
     const user = request.user!;
     
     if (!allowedRoles.includes(user.role)) {
-      console.log(`Auth: User ${user.email} role ${user.role} not in allowed roles: ${allowedRoles.join(', ')}`);
+      if (shouldLog) {
+        console.log(`Auth: User ${user.email} role ${user.role} not in allowed roles: ${allowedRoles.join(', ')}`);
+      }
       return reply.code(403).send({
         error: 'Insufficient privileges',
         message: `One of these roles required: ${allowedRoles.join(', ')}`,
@@ -86,7 +98,9 @@ export const requireAnyRole = (allowedRoles: UserRole[]) => {
       });
     }
     
-    console.log(`Auth: User ${user.email} has allowed role: ${user.role}`);
+    if (shouldLog) {
+      console.log(`Auth: User ${user.email} has allowed role: ${user.role}`);
+    }
   };
 };
 
@@ -103,7 +117,9 @@ export const requirePermission = (requiredPermission: Permission) => {
     const user = request.user!;
     
     if (!hasPermission(user.role, requiredPermission)) {
-      console.log(`Auth: User ${user.email} role ${user.role} lacks permission: ${requiredPermission}`);
+      if (shouldLog) {
+        console.log(`Auth: User ${user.email} role ${user.role} lacks permission: ${requiredPermission}`);
+      }
       return reply.code(403).send({
         error: 'Insufficient privileges',
         message: `Permission ${requiredPermission} required`,
@@ -113,7 +129,9 @@ export const requirePermission = (requiredPermission: Permission) => {
       });
     }
     
-    console.log(`Auth: User ${user.email} has required permission: ${requiredPermission}`);
+    if (shouldLog) {
+      console.log(`Auth: User ${user.email} has required permission: ${requiredPermission}`);
+    }
   };
 };
 
@@ -134,7 +152,9 @@ export const requireAnyPermission = (allowedPermissions: Permission[]) => {
     );
     
     if (!hasAnyPermission) {
-      console.log(`Auth: User ${user.email} role ${user.role} lacks any of permissions: ${allowedPermissions.join(', ')}`);
+      if (shouldLog) {
+        console.log(`Auth: User ${user.email} role ${user.role} lacks any of permissions: ${allowedPermissions.join(', ')}`);
+      }
       return reply.code(403).send({
         error: 'Insufficient privileges',
         message: `One of these permissions required: ${allowedPermissions.join(', ')}`,
@@ -144,7 +164,9 @@ export const requireAnyPermission = (allowedPermissions: Permission[]) => {
       });
     }
     
-    console.log(`Auth: User ${user.email} has required permissions`);
+    if (shouldLog) {
+      console.log(`Auth: User ${user.email} has required permissions`);
+    }
   };
 };
 
@@ -177,12 +199,18 @@ export const optionalAuth = async (request: FastifyRequest, reply: FastifyReply)
   if (request.headers.authorization) {
     try {
       await request.jwtVerify();
-      console.log(`Optional Auth: User ${request.user?.email} authenticated`);
+      if (shouldLog) {
+        console.log(`Optional Auth: User ${request.user?.email} authenticated`);
+      }
     } catch (err) {
       // Silently ignore auth errors for optional auth
-      console.log('Optional Auth: Invalid token ignored');
+      if (shouldLog) {
+        console.log('Optional Auth: Invalid token ignored');
+      }
     }
   } else {
-    console.log('Optional Auth: No token provided');
+    if (shouldLog) {
+      console.log('Optional Auth: No token provided');
+    }
   }
 }; 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -291,14 +291,16 @@ const start = async () => {
     const host = process.env.HOST || '0.0.0.0'
     
     await app.listen({ port, host })
-    
-    console.log(`
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(`
 🚀 AgileForge Backend v2.0 Started Successfully!
 📍 Server running on http://${host}:${port}
 🔐 RBAC Enabled with 5 user roles
 🏗️  Modular architecture implemented
 ✅ JWT Security configured
-    `)
+      `)
+    }
   } catch (err) {
     app.log.error(err)
     process.exit(1)

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,10 +8,12 @@ import EntityListPage from './pages/EntityListPage'
 import AdvancedWorkflowPage from './pages/AdvancedWorkflowPage'
 import { useAuth } from './store/useAuth'
 
+const isDevelopment = import.meta.env.DEV
+
 function requireAuth() {
   // Check if we're in the browser
   if (typeof window === 'undefined') {
-    console.log('requireAuth: Not in browser, returning null')
+    if (isDevelopment) console.log('requireAuth: Not in browser, returning null')
     return null
   }
   
@@ -19,16 +21,16 @@ function requireAuth() {
   const authState = useAuth.getState()
   const token = authState.token || localStorage.getItem('token')
   
-  console.log('requireAuth: token from auth store:', authState.token ? 'exists' : 'null')
-  console.log('requireAuth: token from localStorage:', localStorage.getItem('token') ? 'exists' : 'null')
-  console.log('requireAuth: using token:', token ? 'exists' : 'null')
+  if (isDevelopment) console.log('requireAuth: token from auth store:', authState.token ? 'exists' : 'null')
+  if (isDevelopment) console.log('requireAuth: token from localStorage:', localStorage.getItem('token') ? 'exists' : 'null')
+  if (isDevelopment) console.log('requireAuth: using token:', token ? 'exists' : 'null')
   
   if (!token) {
-    console.log('requireAuth: No token, redirecting to login')
+    if (isDevelopment) console.log('requireAuth: No token, redirecting to login')
     throw redirect('/login')
   }
-  
-  console.log('requireAuth: Token exists, allowing access')
+
+  if (isDevelopment) console.log('requireAuth: Token exists, allowing access')
   return null
 }
 


### PR DESCRIPTION
## Summary
- gate server logs behind `process.env.NODE_ENV !== 'production'`
- use DEV flag for router debug messages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684494550fe08330b5ddfddfbd03f452