### PR TITLE
Refactor forms to use apiClient

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,10 +17,10 @@ function requireAuth() {
   
   // Check the auth store first, then fall back to localStorage
   const authState = useAuth.getState()
-  const token = authState.token || localStorage.getItem('token')
-  
+  const token = authState.token || localStorage.getItem('auth_token')
+
   console.log('requireAuth: token from auth store:', authState.token ? 'exists' : 'null')
-  console.log('requireAuth: token from localStorage:', localStorage.getItem('token') ? 'exists' : 'null')
+  console.log('requireAuth: token from localStorage:', localStorage.getItem('auth_token') ? 'exists' : 'null')
   console.log('requireAuth: using token:', token ? 'exists' : 'null')
   
   if (!token) {


### PR DESCRIPTION
## Summary
- refactor StoryForm and TaskForm to use shared apiClient
- standardize token key usage across router and forms
- remove unused import from StoryForm

## Testing
- `npm test` *(fails: jest not found)*
- `cd backend && npm run lint` *(fails: ESLint config missing)*
- `cd frontend && npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844940dbc0c8330a1f2b84b21b4dc84