### PR TITLE
Add manual dark mode toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,14 @@
     <title>AgileForge Enterprise</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/src/styles/theme.css" />
+    <script>
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'dark') {
+        document.documentElement.classList.add('dark-theme');
+      } else if (savedTheme === 'light') {
+        document.documentElement.classList.add('light-theme');
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../store/useAuth'
 import { Entity } from '../hooks/useEntity'
+import { applyTheme, initTheme, Theme } from '../utils/theme'
 
 const navigation: { name: string; href: string; icon: string; entity: Entity }[] = [
   { name: 'Dashboard', href: '/', icon: '📊', entity: 'projects' },
@@ -20,6 +21,14 @@ export default function Layout() {
   const navigate = useNavigate()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [theme, setTheme] = useState<Theme>(() => initTheme())
+
+  const toggleTheme = () => {
+    const next: Theme = theme === 'light' ? 'dark' : 'light'
+    setTheme(next)
+    applyTheme(next)
+    localStorage.setItem('theme', next)
+  }
 
   const handleLogout = () => {
     logout()
@@ -174,13 +183,23 @@ export default function Layout() {
               </div>
 
               {/* Notifications */}
-              <button 
+              <button
                 className="notification-btn"
                 aria-label="View notifications"
                 title="View notifications"
               >
                 <span>🔔</span>
                 <span className="notification-badge"></span>
+              </button>
+
+              {/* Theme toggle */}
+              <button
+                className="theme-toggle-btn"
+                onClick={toggleTheme}
+                aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {theme === 'dark' ? '☀️' : '🌙'}
               </button>
             </div>
           </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,11 +5,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { router } from './router'
 import { useAuth } from './store/useAuth'
 import { apiClient } from './services/api'
+import { initTheme } from './utils/theme'
 import './styles/global.css'
 import './styles/agile-workflow.css'
 
 const TOKEN_STORAGE_KEY = 'auth_token' // Standardized key
 const isDevelopment = import.meta.env.DEV
+
+// Apply saved theme preference
+initTheme()
 
 // Initialize auth token from storage
 const initializeAuth = () => {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -100,6 +100,25 @@
   }
 }
 
+/* Manual theme classes */
+.dark-theme {
+  --background: var(--gray-900);
+  --surface: var(--gray-800);
+  --border: var(--gray-700);
+  --text-primary: var(--gray-100);
+  --text-secondary: var(--gray-300);
+  --text-muted: var(--gray-500);
+}
+
+.light-theme {
+  --background: #ffffff;
+  --surface: #f8fafc;
+  --border: var(--gray-200);
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-600);
+  --text-muted: var(--gray-400);
+}
+
 /* ===== Reset & Base Styles ===== */
 * {
   box-sizing: border-box;
@@ -1033,6 +1052,21 @@ tr:hover td {
 }
 
 .notification-btn:hover {
+  color: var(--text-secondary);
+  background-color: var(--gray-100);
+}
+
+.theme-toggle-btn {
+  padding: var(--space-2);
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.theme-toggle-btn:hover {
   color: var(--text-secondary);
   background-color: var(--gray-100);
 }

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -1,0 +1,24 @@
+export type Theme = 'light' | 'dark'
+
+export function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark-theme')
+    root.classList.remove('light-theme')
+  } else {
+    root.classList.add('light-theme')
+    root.classList.remove('dark-theme')
+  }
+}
+
+export function initTheme(): Theme {
+  const stored = (typeof window !== 'undefined') ? (localStorage.getItem('theme') as Theme | null) : null
+  if (stored === 'light' || stored === 'dark') {
+    applyTheme(stored)
+    return stored
+  }
+  const prefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+  const theme: Theme = prefersDark ? 'dark' : 'light'
+  applyTheme(theme)
+  return theme
+}


### PR DESCRIPTION
## Summary
- add dark & light theme helpers
- initialize theme in `main.tsx`
- add toggle button to Layout
- ensure saved theme applied on page load

## Testing
- `CI=true npm test` *(fails: API Client token management tests)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6ef04b083308478224f3892372c